### PR TITLE
Fix backend port mismatch

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -292,5 +292,5 @@ app.post('/proxy/n8n/workflows', async (req, res) => {
 });
 
 // --- Start server ---
-const PORT = process.env.PORT || 3002;
+const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- adjust backend default port to `3001`

## Testing
- `npm test -- --coverage --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6889e6683084832588e04572a44db5b5